### PR TITLE
Fix sendSingleSmsPost to accept a comma-separated string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ To send a single SMS, you can use the `sendSingleSmsPost` method for POST reques
 
 #### POST Example
 
-You can pass a single number or multiple numbers as an array (Numbers can start with 07, 0 or 254):
+You can pass a single number or a comma separated set of numbers  (Numbers can start with 07, 0 or 254):
 
 ```php
-$response = $smsApi->sendSingleSmsPost(['07xxxxxxxxxx', '07xxxxxxxxx'], 'Your message here', 'timeToSend', null);
+$response = $smsApi->sendSingleSmsPost('07xxxxxxxxxx,07xxxxxxxxx', 'Your message here', 'timeToSend', null);
 ```
 
 #### GET Example

--- a/src/SendSms.php
+++ b/src/SendSms.php
@@ -58,7 +58,7 @@ class SendSms extends BaseFile
      * @throws GuzzleException If the request fails.
      */
 
-    public function sendSingleSmsPost(array $msisdn, string $message, string $time = null, string $hashed = null): string
+    public function sendSingleSmsPost(string $msisdn, string $message, string $time = null, string $hashed = null): string
     {
 
         $msisdnString = implode(',', $msisdn);


### PR DESCRIPTION
This pull request updates the `sendSingleSmsPost` method to accept a comma-separated string for mobile numbers instead of an array. This change is necessary to comply with the API's requirements.


- Updated the method signature from:
  ```php
  public function sendSingleSmsPost(array $msisdn, string $message, string $time = null, string $hashed = null): string

to

public function sendSingleSmsPost(string $msisdn, string $message, string $time = null, string $hashed = null): string
